### PR TITLE
chore: bump app image tag to 1.0.1

### DIFF
--- a/manifests/helm-chart/values.yaml
+++ b/manifests/helm-chart/values.yaml
@@ -1,8 +1,7 @@
-imageVersion: 0.1.0
+imageVersion: 1.0.1
 replicaCount: 3
 image: gitopsitmo/gitops-app
 app: demo-app
-
 resources:
   requests:
     memory: "256Mi"
@@ -10,7 +9,6 @@ resources:
   limits:
     memory: "512Mi"
     cpu: "500m"
-
 ports:
   port: 8080
   nodePort: 30080

--- a/manifests/k8s/deployment.yaml
+++ b/manifests/k8s/deployment.yaml
@@ -19,18 +19,18 @@ spec:
       automountServiceAccountToken: false
       # Security context на уровне Pod
       securityContext:
-        runAsNonRoot: true        # Запрещаем запуск от root
-        runAsUser: 10000          # Запускаем от пользователя с высоким UID
+        runAsNonRoot: true # Запрещаем запуск от root
+        runAsUser: 10000 # Запускаем от пользователя с высоким UID
         seccompProfile:
-          type: RuntimeDefault     # Включаем seccomp защиту
+          type: RuntimeDefault # Включаем seccomp защиту
       imagePullSecrets:
         - name: docker-registry-secret
       nodeSelector:
         zone: dev
       containers:
         - name: demo-app
-          image: gitopsitmo/gitops-app:0.1.0  # Рекомендуется перейти на digest
-          imagePullPolicy: Always  # Добавляем Always
+          image: gitopsitmo/gitops-app:1.0.1 # Рекомендуется перейти на digest
+          imagePullPolicy: Always # Добавляем Always
           ports:
             - name: http
               containerPort: 8080
@@ -40,14 +40,14 @@ spec:
                 name: app-config
           # Security context на уровне Container
           securityContext:
-            allowPrivilegeEscalation: false  # Запрещаем эскалацию привилегий
-            readOnlyRootFilesystem: true     # Файловая система только для чтения
+            allowPrivilegeEscalation: false # Запрещаем эскалацию привилегий
+            readOnlyRootFilesystem: true # Файловая система только для чтения
             runAsNonRoot: true
             runAsUser: 10000
             capabilities:
               drop:
-                - ALL              # Убираем ВСЕ capabilities
-                - NET_RAW          # Явно убираем NET_RAW
+                - ALL # Убираем ВСЕ capabilities
+                - NET_RAW # Явно убираем NET_RAW
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
Automated update triggered by `sync-version-to-manifests` in `devops-itmo-learn/gitops_source`.
- Source commit: `45f27295ea2484aef24008042ea3d40a7b096e5d`
- New application version: `1.0.1`